### PR TITLE
Fix checkpoints downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if os.environ.get('READTHEDOCS'):
 
 setup(
     name='terran',
-    version='0.1.1-dev',
+    version='0.1.2-dev',
 
     author='Agustín Azzinnari',
     author_email='me@nagitsu.com',


### PR DESCRIPTION
This commit replaces the checkpoint download URLs since they changed
after the first alpha release name was updated.

Also, I improve the error handling when downloading checkpoints if it
happens that there's an issue downloading them.

Finally, I added the option to not-prompt for download if the user is
not running Terran inside an interactive terminal.