### PR TITLE
Replace Lycon with OpenCV

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ autoclass_content = 'both'
 # Mock dependencies that have C-extensions.
 autodoc_mock_imports = [
     'cairo',
-    'lycon'
+    'opencv-python'
 ]
 
 templates_path = ['_templates']

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -20,6 +20,13 @@ Terran makes use of `FFmpeg <https://www.ffmpeg.org>`_ in order to provide
 I/O-related functions for videos. As such, make sure you have it installed as a
 system dependency if you want to run predictions on videos.
 
+OpenCV
+^^^^^^
+
+Terran will use `OpenCV <https://docs.opencv.org/master/>` to efficiently resize images and
+considerably accelerate the face tracking process. Make sure you have all system dependencies to
+install OpenCV correctly on your machine.
+
 Cairo
 ^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,12 @@ INSTALL_REQUIRES = [
     'click',
     'ffmpeg-python',
     'filterpy',
-    'lycon',
+    'opencv-python-headless',
     'numpy',
     'pycairo',
     'requests',
     'scikit-image',
-    'sklearn',
+    'scikit-learn>=0.21',
     'torch',
     'torchvision',
 ]
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = [
 # list should match `autodoc_mock_imports` in `docs/conf.py`, but with the
 # package names instead of the top-level modules.
 MOCKED_IN_DOCS = [
-    'lycon',
+    'opencv-python',
     'pycairo',
 ]
 
@@ -38,8 +38,7 @@ if os.environ.get('READTHEDOCS'):
 
 setup(
     name='terran',
-    version='0.1.2-dev',
-
+    version='0.1.1-dev',
     author='Agustín Azzinnari',
     author_email='me@nagitsu.com',
     description='A human perception library',

--- a/terran/face/detection/__init__.py
+++ b/terran/face/detection/__init__.py
@@ -1,8 +1,7 @@
-import lycon
 import math
 import numpy as np
 
-from lycon import resize
+from cv2 import resize, INTER_LINEAR
 
 from terran import default_device
 from terran.checkpoint import get_class_for_checkpoint
@@ -32,9 +31,10 @@ def resize_factory(short_side=416):
             )
             for idx, image in enumerate(images):
                 resize(
-                    image, output=resized[idx],
-                    width=new_size[0], height=new_size[1],
-                    interpolation=lycon.Interpolation.LINEAR
+                    src=image,
+                    dst=resized[idx],
+                    dsize=new_size,
+                    interpolation=INTER_LINEAR
                 )
             scales = scale
         else:
@@ -47,8 +47,9 @@ def resize_factory(short_side=416):
 
                 resized.append(
                     resize(
-                        image, width=new_size[0], height=new_size[1],
-                        interpolation=lycon.Interpolation.LINEAR
+                        src=image,
+                        dsize=new_size,
+                        interpolation=INTER_LINEAR
                     )
                 )
                 scales.append(scale)

--- a/terran/pose/openpose/wrapper.py
+++ b/terran/pose/openpose/wrapper.py
@@ -1,8 +1,7 @@
 import numpy as np
-import lycon
 import torch
 
-from lycon import resize
+from cv2 import resize, INTER_LINEAR
 
 from terran import default_device
 from terran.checkpoint import get_checkpoint_path
@@ -100,9 +99,10 @@ def resize_images(images, short_side=416):
     )
     for idx, image in enumerate(images):
         resize(
-            image, output=resized[idx],
-            width=new_size[0], height=new_size[1],
-            interpolation=lycon.Interpolation.LINEAR
+            src=image,
+            dst=resized[idx],
+            dsize=new_size,
+            interpolation=INTER_LINEAR,
         )
 
     return resized, scale

--- a/terran/tracking/face.py
+++ b/terran/tracking/face.py
@@ -1,9 +1,14 @@
 import numpy as np
 
 from filterpy.kalman import KalmanFilter
-from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment
 
 from terran.face.detection import Detection, face_detection
+
+
+def linear_assignment(cost_matrix):
+    """Implement the linear assignment as in Scikit Learn v0.21"""
+    return np.transpose(np.asarray(linear_sum_assignment(cost_matrix)))
 
 
 def iou(bbox_1, bbox_2):


### PR DESCRIPTION
Replaces the Lycon library with OpenCV. This is a major change.

I added OpenCV-headless as a dependency for Terran, and also changed the
documentation to state that OpenCV is a dependency.